### PR TITLE
Fix npm audit warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "url": "https://github.com/morganherlocker/bbox-intersect/issues"
   },
   "homepage": "https://github.com/morganherlocker/bbox-intersect",
-  "dependencies": {
-    "tape": "^2.14.0"
+  "dependencies": {},
+  "devDependencies": {
+    "tape": "^4.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbox-intersect",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "bbox-intersect ==============",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Minor fix eliminates `npm audit` warnings.
Also makes `tape` a devDependency because it is not needed outside of dev.

`npm test` still works as expected.